### PR TITLE
Some iOS simulators generate invalid name during generate

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -71,7 +71,7 @@ function generate() {
               return;
             }
 
-            var name = dev.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+            var name = dev.name.toLowerCase().replace(/[()]/g, '').replace(/[^a-z0-9]+/g, '-');
             var recipe = ['--ios', '--device', '--device-id', dev.udid];
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "alloy",
     "cli"
   ],
-  "version": "4.2.0",
+  "version": "4.2.1",
   "author": {
     "name": "Fokke Zandbergen",
     "email": "mail@fokkezb.nl"


### PR DESCRIPTION
Correct issue where iOS simulators ending with parenthesis cause an invalid name to be generated; bump patch version.