### PR TITLE
Fix for invalid recipe name for iPad simulators.

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -39,7 +39,7 @@ function generate() {
         if (config.android.emulators && config.android.emulators.length > 0) {
 
           config.android.emulators.forEach(function forEach(dev) {
-            var name = dev.name.toLowerCase().replace(/\.+/g, '').replace(/[^a-z0-9]+/g, '-');
+            var name = dev.name.toLowerCase().replace(/\.+/g, '').replace(/[^a-z0-9]+/g, '-').replace(/-$/,'');
             var recipe = ['--android', '--emulator', '--device-id', dev.name];
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
@@ -51,7 +51,7 @@ function generate() {
         if (config.android.devices && config.android.devices.length > 0) {
 
           config.android.devices.forEach(function forEach(dev) {
-            var name = dev.name.toLowerCase().replace(/\.+/g, '').replace(/[^a-z0-9]+/g, '-');
+            var name = dev.name.toLowerCase().replace(/\.+/g, '').replace(/[^a-z0-9]+/g, '-').replace(/-$/,'');
             var recipe = ['--android', '--device', '--device-id', dev.id];
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
@@ -71,7 +71,7 @@ function generate() {
               return;
             }
 
-            var name = dev.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+            var name = dev.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-$/,'');
             var recipe = ['--ios', '--device', '--device-id', dev.udid];
 
             if (!recipes.has(name) || !arraysIdentical(recipes.get(name), recipe)) {
@@ -97,7 +97,7 @@ function generate() {
           versions.forEach(function forEach(version) {
 
             iosSims[version].forEach(function forEach(dev) {
-              var name = dev.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+              var name = dev.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-$/,'');
               var recipe = ['--ios', '--simulator', '--device-id', dev.udid];
 
               if (recipes.has(name) && versions[0] !== version) {


### PR DESCRIPTION
Fixes #53 by trimming the trailing dash.